### PR TITLE
Update match URL for version 3.9

### DIFF
--- a/release/index.user.js
+++ b/release/index.user.js
@@ -4,7 +4,7 @@
 // @version      0.7.13
 // @description  Improve your plane with the interface that offers experimental features.
 // @author       Ferhatduran55
-// @match        https://www.geo-fs.com/geofs.php?v=3.7
+// @match        https://www.geo-fs.com/geofs.php?v=3.9
 // @grant        GM_addStyle
 // @grant        GM_setValue
 // @grant        GM_getValue


### PR DESCRIPTION
This pull request updates the userscript to support the latest version of the GeoFS website.

- Compatibility update:
  * Changed the `@match` metadata in `release/index.user.js` to target `https://www.geo-fs.com/geofs.php?v=3.9` instead of `v=3.7`, ensuring the script works with the new site version.